### PR TITLE
非同期から同期処理に変更

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const fileName = './test.txt';
 for (let count = 0; count < 30; count++) {
-    fs.appendFile(fileName, 'おはようございます\n', 'utf8');
-    fs.appendFile(fileName, 'こんにちは\n', 'utf8');
-    fs.appendFile(fileName, 'こんばんは\n', 'utf8');
+    fs.appendFileSync(fileName, 'おはようございます\n', 'utf8');
+    fs.appendFileSync(fileName, 'こんにちは\n', 'utf8');
+    fs.appendFileSync(fileName, 'こんばんは\n', 'utf8');
 }


### PR DESCRIPTION
マージ不要です。

async-io-problemを取得実行すると　320回以上の繰り返しで処理しようとしたら
以下のようなエラーになるので回数を減らして実行しました。
fs.js:101
      throw err;  // Forgot a callback but don't know where? Use NODE_DEBUG=fs
      ^
Error: EMFILE: too many open files, open './test.txt'
    at Error (native)

他は、問題なく出来ました。